### PR TITLE
Bug fix for multi-device/session users on the same frontend and add getStatusByUid and getStatusByUids methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 !.gitignore
-node_modules/*
+/node_modules

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ get frontend server id by user id
 + err - error
 + list - array of frontend server ids
 
-###getStatusByUid(uids, cb)
+###getStatusByUid(uid, cb)
 ####Arguments
 + uid - user id
 + cb - callback function
@@ -43,6 +43,15 @@ get frontend server id by user id
 ####Return
 + err - error
 + status - boolean, true if user is online (at least one session with a frontend) or false otherwise
+
+###getStatusByUids(uids, cb)
+####Arguments
++ uids - array of user ids
++ cb - callback function
+
+####Return
++ err - error
++ statuses - object with uid as keys and boolean as value, true if user is online (at least one session with a frontend) or false otherwise
 
 ###pushByUids(uids, route, msg, cb)
 ####Arguments

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ get frontend server id by user id
 + err - error
 + list - array of frontend server ids
 
+###getStatusByUid(uids, cb)
+####Arguments
++ uid - user id
++ cb - callback function
+
+####Return
++ err - error
++ status - boolean, true if user is online (at least one session with a frontend) or false otherwise
+
 ###pushByUids(uids, route, msg, cb)
 ####Arguments
 + uids - array of user ids

--- a/lib/events/event.js
+++ b/lib/events/event.js
@@ -24,6 +24,12 @@ Event.prototype.close_session = function(session) {
   if(!session.uid) {
     return;
   }
+  // don't remove entry if another session for the same user on the same frontend remain
+  var currentUserSessions = this.app.get('sessionService').getByUid(session.uid);
+  if (currentUserSessions !== undefined) {
+    logger.debug('at least another session exists for this user on this frontend: [%s] [%s]', session.uid, session.frontendId);
+    return;
+  }
   this.statusService.leave(session.uid, session.frontendId, function(err) {
     if(!!err) {
       logger.error('failed to kick user in statusService: [%s] [%s], err: %j', session.uid, session.frontendId, err);

--- a/lib/manager/statusManager.js
+++ b/lib/manager/statusManager.js
@@ -66,13 +66,23 @@ StatusManager.prototype.getSidsByUid = function(uid, cb) {
   });
 };
 
+StatusManager.prototype.getSidsByUids = function(uids, cb) {
+  var cmds = [];
+  for (var i=0; i<uids.length; i++) {
+    cmds.push(['exists', genKey(this, uids[i])]);
+  }
+  execMultiCommands(this.redis, cmds, function(err, list) {
+    utils.invokeCallback(cb, err, list);
+  });
+};
+
 var execMultiCommands = function(redis, cmds, cb) {
   if(!cmds.length) {
     utils.invokeCallback(cb);
     return;
   }
-  redis.multi(cmds).exec(function(err, reply) {
-    utils.invokeCallback(cb, err);
+  redis.multi(cmds).exec(function(err, replies) {
+    utils.invokeCallback(cb, err, replies);
   });
 };
 

--- a/lib/service/statusService.js
+++ b/lib/service/statusService.js
@@ -106,6 +106,29 @@ StatusService.prototype.getStatusByUid = function(uid, cb) {
   });
 };
 
+StatusService.prototype.getStatusByUids = function(uids, cb) {
+  if(this.state !== ST_STARTED) {
+    utils.invokeCallback(cb, new Error('invalid state'));
+    return;
+  }
+
+  this.manager.getSidsByUids(uids, function(err, replies) {
+    if (!!err) {
+      utils.invokeCallback(cb, new Error(util.format('failed to get serverIds by uids, err: %j', err.stack)), null);
+      return;
+    }
+
+    var statuses = {};
+    for (var i=0; i<uids.length; i++) {
+      statuses[uids[i]] = (replies[i] == 1)
+        ? true // online
+        : false; // offline
+    }
+
+    utils.invokeCallback(cb, null, statuses);
+  });
+};
+
 
 StatusService.prototype.pushByUids = function(uids, route, msg, cb) {
   if(this.state !== ST_STARTED) {

--- a/lib/service/statusService.js
+++ b/lib/service/statusService.js
@@ -88,6 +88,24 @@ StatusService.prototype.getSidsByUid = function(uid, cb) {
   this.manager.getSidsByUid(uid, cb);
 };
 
+StatusService.prototype.getStatusByUid = function(uid, cb) {
+  if(this.state !== ST_STARTED) {
+    utils.invokeCallback(cb, new Error('invalid state'));
+    return;
+  }
+
+  this.manager.getSidsByUid(uid, function(err, list) {
+    if (!!err) {
+      utils.invokeCallback(cb, new Error(util.format('failed to get serverIds by uid: [%s], err: %j', uid, err.stack)), null);
+      return;
+    }
+    var status = (list !== undefined && list.length >= 1)
+      ? true // online
+      : false; // offline
+    utils.invokeCallback(cb, null, status);
+  });
+};
+
 
 StatusService.prototype.pushByUids = function(uids, route, msg, cb) {
   if(this.state !== ST_STARTED) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomelo-status-plugin",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "author": "py8765 pengyang633@126.com/@py8765",
   "contributors":[

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomelo-status-plugin",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": false,
   "author": "py8765 pengyang633@126.com/@py8765",
   "contributors":[


### PR DESCRIPTION
Originally on session disconnect the module removes the record from persistence for this user@frontend.
Add a test to check if at least another session remain for this user@frontend before record deletion.
