### PR TITLE
修复statusService不能使用自定义statusManager的bug.

### DIFF
--- a/lib/manager/statusManager.js
+++ b/lib/manager/statusManager.js
@@ -9,12 +9,27 @@ var StatusManager = function(app, opts) {
   this.prefix = opts.prefix || DEFAULT_PREFIX;
   this.host = opts.host;
   this.port = opts.port;
+  this.slaveConf = opts.slaveConf;
   this.redis = null;
+  this.redisSlaves = [];
 };
 
 module.exports = StatusManager;
 
 StatusManager.prototype.start = function(cb) {
+  var self = this;
+  //init redis slaves
+  this.slaveConf.forEach(function(conf){
+    var slave = redis.createClient(conf.port, conf.host);
+    if(conf.auth_pass) {
+      slave.auth(conf.auth_pass);
+    }
+    slave.on("error", function(err){
+      console.error("[status-plugin][redis-slave]"+ err.stack);
+    });
+    self.redisSlaves.push(slave);
+  });
+  //init redis master
 	this.redis = redis.createClient(this.port, this.host, this.opts);
   if (this.opts.auth_pass) {
     this.redis.auth(this.opts.auth_pass);
@@ -30,9 +45,15 @@ StatusManager.prototype.stop = function(force, cb) {
     this.redis.end();
     this.redis = null;
   }
+  //stop slaves
+  this.redisSlaves.forEach(function(slave){
+    slave.end();
+  });
+  this.redisSlaves = [];
   utils.invokeCallback(cb);
 };
 
+//clean on master
 StatusManager.prototype.clean = function(cb) {
   var cmds = [];
   var self = this;
@@ -48,30 +69,34 @@ StatusManager.prototype.clean = function(cb) {
   });
 };
 
+//write on master
 StatusManager.prototype.add = function(uid, sid ,cb) {
  	this.redis.sadd(genKey(this, uid), sid, function(err) {
     utils.invokeCallback(cb, err);
   });
 };
 
+//write on master
 StatusManager.prototype.leave = function(uid, sid, cb) {
 	this.redis.srem(genKey(this, uid), sid, function(err) {
     utils.invokeCallback(cb, err);
   });
 };
 
+//read on slave
 StatusManager.prototype.getSidsByUid = function(uid, cb) {
-  this.redis.smembers(genKey(this, uid), function(err, list) {
+  randomRedisSlave(this).smembers(genKey(this, uid), function(err, list) {
     utils.invokeCallback(cb, err, list);
   });
 };
 
+//read on slave
 StatusManager.prototype.getSidsByUids = function(uids, cb) {
   var cmds = [];
   for (var i=0; i<uids.length; i++) {
     cmds.push(['exists', genKey(this, uids[i])]);
   }
-  execMultiCommands(this.redis, cmds, function(err, list) {
+  execMultiCommands(randomRedisSlave(this), cmds, function(err, list) {
     utils.invokeCallback(cb, err, list);
   });
 };
@@ -92,4 +117,9 @@ var genKey = function(self, uid) {
 
 var genCleanKey = function(self) {
   return self.prefix + '*';
+};
+
+//return random redis slave instance.
+var randomRedisSlave = function(self){
+  return self.redisSlaves[Math.floor(Math.random()*self.redisSlaves.length)];
 };

--- a/lib/service/statusService.js
+++ b/lib/service/statusService.js
@@ -177,7 +177,7 @@ var getStatusManager = function(app, opts) {
   var manager;
   
   if(typeof opts.statusManager === 'function') {
-    manager = opts.statusManager(app, opts);
+    manager = new opts.statusManager(app, opts);
   } else {
     manager = opts.statusManager;
   }


### PR DESCRIPTION
statusService.js中getStatusManager方法存在bug，只能返回DefaultStatusManager而不能使用用户自定义statusManager。
忽略statusManager.js
