### PR TITLE
* clean only the keys generated by the current server

### DIFF
--- a/lib/manager/statusManager.js
+++ b/lib/manager/statusManager.js
@@ -36,32 +36,35 @@ StatusManager.prototype.stop = function(force, cb) {
 StatusManager.prototype.clean = function(cb) {
   var cmds = [];
   var self = this;
-  this.redis.keys(genCleanKey(this), function(err, list) {
+  this.redis.smembers(genSidKey(this), function(err, list) {
     if(!!err) {
       utils.invokeCallback(cb, err);
       return;
     }
     for(var i=0; i<list.length; i++) {
-      cmds.push(['del', list[i]]);
+      cmds.push(['srem', genUidKey(self, list[i]), self.app.serverId]);
     }
+    cmds.push(['del', genSidKey(self)]);
     execMultiCommands(self.redis, cmds, cb);
   });
 };
 
 StatusManager.prototype.add = function(uid, sid ,cb) {
- 	this.redis.sadd(genKey(this, uid), sid, function(err) {
-    utils.invokeCallback(cb, err);
-  });
+  var cmds = [];
+  cmds.push(['sadd', genSidKey(this), uid]);
+  cmds.push(['sadd', genUidKey(this, uid), sid]);
+  execMultiCommands(this.redis, cmds, cb);
 };
 
 StatusManager.prototype.leave = function(uid, sid, cb) {
-	this.redis.srem(genKey(this, uid), sid, function(err) {
-    utils.invokeCallback(cb, err);
-  });
+  var cmds = [];
+  cmds.push(['srem', genSidKey(this), uid]);
+  cmds.push(['srem', genUidKey(this, uid), sid]);
+  execMultiCommands(this.redis, cmds, cb);
 };
 
 StatusManager.prototype.getSidsByUid = function(uid, cb) {
-  this.redis.smembers(genKey(this, uid), function(err, list) {
+  this.redis.smembers(genUidKey(this, uid), function(err, list) {
     utils.invokeCallback(cb, err, list);
   });
 };
@@ -69,7 +72,7 @@ StatusManager.prototype.getSidsByUid = function(uid, cb) {
 StatusManager.prototype.getSidsByUids = function(uids, cb) {
   var cmds = [];
   for (var i=0; i<uids.length; i++) {
-    cmds.push(['exists', genKey(this, uids[i])]);
+    cmds.push(['exists', genUidKey(this, uids[i])]);
   }
   execMultiCommands(this.redis, cmds, function(err, list) {
     utils.invokeCallback(cb, err, list);
@@ -86,10 +89,10 @@ var execMultiCommands = function(redis, cmds, cb) {
   });
 };
 
-var genKey = function(self, uid) {
-  return self.prefix + ':' + uid;
+var genUidKey = function(self, uid) {
+  return self.prefix + ':UID:' + uid;
 };
 
-var genCleanKey = function(self) {
-  return self.prefix + '*';
+var genSidKey = function(self) {
+  return self.prefix + ':SID:' + self.app.serverId;
 };

--- a/lib/manager/statusManager.js
+++ b/lib/manager/statusManager.js
@@ -64,8 +64,29 @@ StatusManager.prototype.leave = function(uid, sid, cb) {
 };
 
 StatusManager.prototype.getSidsByUid = function(uid, cb) {
+  var self = this;
+
   this.redis.smembers(genUidKey(this, uid), function(err, list) {
-    utils.invokeCallback(cb, err, list);
+    if(!!err) {
+      utils.invokeCallback(cb, err);
+      return;
+    }
+    var commands = [];
+    var sids = [];
+    for(var i=0; i<list.length; i++) {
+      var sid = list[i];
+      var server = self.app.getServerById(sid);
+      if (!server) {
+        commands.push(['srem', genOtherSidKey(self, sid), uid]);
+        commands.push(['srem', genUidKey(self, uid), sid]);
+      } else {
+        sids.push(sid);
+      }
+    }
+
+    execMultiCommands(self.redis, commands, function (err) {
+      utils.invokeCallback(cb, err, sids);
+    });
   });
 };
 
@@ -95,4 +116,8 @@ var genUidKey = function(self, uid) {
 
 var genSidKey = function(self) {
   return self.prefix + ':SID:' + self.app.serverId;
+};
+
+var genOtherSidKey = function(self, sid) {
+  return self.prefix + ':SID:' + sid;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomelo-status-plugin",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": false,
   "author": "py8765 pengyang633@126.com/@py8765",
   "contributors":[


### PR DESCRIPTION
If we have multiple servers using the status plugin when one of them is restarted it will clean all the status keys.
I changed the clean method to only remove the entries for the current server if there are any.
I've added another redis sorted set that keeps all the uids that were set as online for the current sid.